### PR TITLE
Add .gitignore to exclude notebook checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints/


### PR DESCRIPTION
When using this Git repo as the base for exercises, learners will quickly run into issues with changed files that'll make it hard to pull updates from the source repo.

That's an issue anyways if they don't know about branching and work off the `main` branch, but it could be nice to introduce a `.gitignore` file that'll reduce some of the diffing noise (such as the checkpoints).

Open for your thoughts @giladgressel 